### PR TITLE
Fix python-path config

### DIFF
--- a/manifests/apache/vhost.pp
+++ b/manifests/apache/vhost.pp
@@ -105,7 +105,7 @@ class puppetboard::apache::vhost (
 
   $docroot = "${basedir}/puppetboard"
   if $python_path {
-    $_python_path = join($python_path, ":")
+    $python_path_conf = join($python_path, ":")
   }
 
   $wsgi_script_aliases = {
@@ -117,7 +117,7 @@ class puppetboard::apache::vhost (
       threads     => $threads,
       group       => $group,
       user        => $user,
-      python-path => $python_path,
+      python-path => $python_path_conf,
       python-home => $python_home,
     }
   } else {


### PR DESCRIPTION
The string with colon separeted list of directories was built but not used.

Current resulting config:
```
python-path=["/srv/puppetboard/virtenv-puppetboard/lib/python3.6", "/srv/puppetboard/virtenv-puppetboard/lib/python3.6/site-packages", "/srv/puppetboard/puppetboard"]
```

But the desired is:
```
python-path="/srv/puppetboard/virtenv-puppetboard/lib/python3.6:/srv/puppetboard/virtenv-puppetboard/lib/python3.6/site-packages:/srv/puppetboard/puppetboard"
```

Reference: https://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIDaemonProcess.html

The current ouput generates the following error:
```
systemd[1]: Starting The Apache HTTP Server...
httpd[18962]: AH00526: Syntax error on line 24 of /etc/httpd/conf.d/25-puppet.dev.conf:
httpd[18962]: Invalid option to WSGI daemon process definition.
systemd[1]: httpd.service: main process exited, code=exited, status=1/FAILURE
```

